### PR TITLE
updated seeds file to reflect faker gem updates

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 
 30.times do 
   Destination.create({
-    name: Faker::GameOfThrones.city,
+    name: Faker::TvShows::GameOfThrones.city,
     country: Faker::Address.country
   })
 end


### PR DESCRIPTION
Database seeding was aborted when creating a new instance of a Destination because tv show names are now nested one level deeper. Note that the seed file is pre-populated for students. 

Faker::GameOfThrones needs to become Faker::TvShows::GameOfThrones. 

https://github.com/faker-ruby/faker/tree/master/lib/faker/tv_shows